### PR TITLE
Update so TD-Launcher will recognize daily build installer signature

### DIFF
--- a/BUILD.bat
+++ b/BUILD.bat
@@ -1,4 +1,9 @@
-.\py\Scripts\pyinstaller.exe --noconfirm --log-level=WARN ^
+@echo off
+setlocal
+
+set PYTHON_EXECUTABLE=.\py\python.exe
+
+%PYTHON_EXECUTABLE% .\py\Scripts\pyinstaller.exe --noconfirm --log-level=WARN ^
 --onefile --nowindow ^
 --windowed ^
 --name="td_launcher" ^
@@ -12,3 +17,5 @@
 --add-binary="toeexpand/libcurl-x64.dll;toeexpand" ^
 --add-binary="toeexpand/zlib1.dll;toeexpand" ^
 .\td_launcher.py
+
+endlocal

--- a/td_launcher.py
+++ b/td_launcher.py
@@ -38,7 +38,7 @@ def query_td_registry_entries():
             break
 
         # if touchdesigner exists in key and if there is no suffix like .Asset or .Component, we save the key.
-        if "TouchDesigner" in key_name and key_name.count('.') == 2:
+        if "TouchDesigner" in key_name and key_name.split('.')[-1].isdigit():
             td_matching_keys += [ key_name ]
     
     td_matching_keys = sorted(td_matching_keys)


### PR DESCRIPTION
New custom builds of TD have a daily number appended to the end of the name so search for 'TouchDesigner' strings in the registry with exactly 2 periods (.) won't append those entries. Instead of looking for 2 periods check if the last entry is digits and assume it relates to a valid build.

Also BUILD.bat has been updated to for force pyinstaller.exe to use the local python.exe
